### PR TITLE
ユーザー登録機構の実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@
 ## Deliver_addressesテーブル
 |Column|Type|Options|
 |------|----|-------|
-|post_code|integer(7)|null: false|
+|post_code|integer|null: false|
 |prefecture_code|integer|null: false|
 |city|string|null: false|
 |house_number|string|null: false|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -2,6 +2,10 @@ class ApplicationController < ActionController::Base
   before_action :basic_auth, if: :production?
   before_action :configure_permitted_parameters, if: :devise_controller?
 
+  def after_sign_out_path_for(resource)
+    new_user_session_path
+  end
+  
   private
 
     def basic_auth
@@ -16,6 +20,10 @@ class ApplicationController < ActionController::Base
     end
 
     def configure_permitted_parameters
-      devise_parameter_sanitizer.permit(:sign_up, keys: [:nickname])
+      devise_parameter_sanitizer.permit(:sign_up, keys: [
+                                                        :nickname, :first_name, :family_name,
+                                                        :first_name_kana, :family_name_kana, :birth_date,
+                                                        :introduction, :icon
+                                                          ])
     end
 end

--- a/app/controllers/users/confirmations_controller.rb
+++ b/app/controllers/users/confirmations_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::ConfirmationsController < Devise::ConfirmationsController
+  # GET /resource/confirmation/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/confirmation
+  # def create
+  #   super
+  # end
+
+  # GET /resource/confirmation?confirmation_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after resending confirmation instructions.
+  # def after_resending_confirmation_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+
+  # The path used after confirmation.
+  # def after_confirmation_path_for(resource_name, resource)
+  #   super(resource_name, resource)
+  # end
+end

--- a/app/controllers/users/omniauth_callbacks_controller.rb
+++ b/app/controllers/users/omniauth_callbacks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::OmniauthCallbacksController < Devise::OmniauthCallbacksController
+  # You should configure your model like this:
+  # devise :omniauthable, omniauth_providers: [:twitter]
+
+  # You should also create an action method in this controller like this:
+  # def twitter
+  # end
+
+  # More info at:
+  # https://github.com/heartcombo/devise#omniauth
+
+  # GET|POST /resource/auth/twitter
+  # def passthru
+  #   super
+  # end
+
+  # GET|POST /users/auth/twitter/callback
+  # def failure
+  #   super
+  # end
+
+  # protected
+
+  # The path used when OmniAuth fails
+  # def after_omniauth_failure_path_for(scope)
+  #   super(scope)
+  # end
+end

--- a/app/controllers/users/passwords_controller.rb
+++ b/app/controllers/users/passwords_controller.rb
@@ -1,0 +1,34 @@
+# frozen_string_literal: true
+
+class Users::PasswordsController < Devise::PasswordsController
+  # GET /resource/password/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/password
+  # def create
+  #   super
+  # end
+
+  # GET /resource/password/edit?reset_password_token=abcdef
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource/password
+  # def update
+  #   super
+  # end
+
+  # protected
+
+  # def after_resetting_password_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after sending reset password instructions
+  # def after_sending_reset_password_instructions_path_for(resource_name)
+  #   super(resource_name)
+  # end
+end

--- a/app/controllers/users/registrations_controller.rb
+++ b/app/controllers/users/registrations_controller.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+class Users::RegistrationsController < Devise::RegistrationsController
+  # before_action :configure_sign_up_params, only: [:create]
+  # before_action :configure_account_update_params, only: [:update]
+
+  # GET /resource/sign_up
+  def new
+    super
+  end
+
+  # POST /resource
+  def create
+    @user = User.new(sign_up_params)
+    unless @user.valid?
+      flash.now[:alert] = @user.errors.full_messages
+      render :new and return
+    end
+    session["devise.regist_data"] = { user: @user.attributes }
+    session["devise.regist_data"][:user]["password"] = params[:user][:password]
+    @deliver_address = @user.build_deliver_address
+    render :new_deliver_address
+  end
+
+  def create_deliver_address
+    @user = User.new(session["devise.regist_data"]["user"])
+    @deliver_address = DeliverAddress.new(deliver_address_params)
+    unless @deliver_address.valid?
+      flash.now[:alert] = @deliver_address.errors.full_messages
+      render :new_deliver_address and return
+    end
+    @user.build_deliver_address(@deliver_address.attributes)
+    @user.save
+    sign_in(:user, @user)
+    redirect_to root_path
+  end
+
+  # GET /resource/edit
+  # def edit
+  #   super
+  # end
+
+  # PUT /resource
+  # def update
+  #   super
+  # end
+
+  # DELETE /resource
+  # def destroy
+  #   super
+  # end
+
+  # GET /resource/cancel
+  # Forces the session data which is usually expired after sign
+  # in to be expired now. This is useful if the user wants to
+  # cancel oauth signing in/up in the middle of the process,
+  # removing all OAuth session data.
+  # def cancel
+  #   super
+  # end
+
+  protected
+
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_sign_up_params
+    #   devise_parameter_sanitizer.permit(:sign_up, keys: [])
+    # end
+
+    def deliver_address_params
+      params.require(:deliver_address).permit(:post_code, :prefecture_code,
+                                              :city, :house_number, :building_name,
+                                              :destination_family_name, :destination_first_name,
+                                              :destination_family_name_kana, :destination_first_name_kana,
+                                              :phone_number)
+    end
+
+    # If you have extra params to permit, append them to the sanitizer.
+    # def configure_account_update_params
+    #   devise_parameter_sanitizer.permit(:account_update, keys: [:attribute])
+    # end
+
+    # The path used after sign up.
+    # def after_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+
+    # The path used after sign up for inactive accounts.
+    # def after_inactive_sign_up_path_for(resource)
+    #   super(resource)
+    # end
+  end

--- a/app/controllers/users/sessions_controller.rb
+++ b/app/controllers/users/sessions_controller.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+class Users::SessionsController < Devise::SessionsController
+  # before_action :configure_sign_in_params, only: [:create]
+
+  # GET /resource/sign_in
+  # def new
+  #   super
+  # end
+
+  # POST /resource/sign_in
+  # def create
+  #   super
+  # end
+
+  # DELETE /resource/sign_out
+  # def destroy
+  #   super
+  # end
+
+  # protected
+
+  # If you have extra params to permit, append them to the sanitizer.
+  # def configure_sign_in_params
+  #   devise_parameter_sanitizer.permit(:sign_in, keys: [:attribute])
+  # end
+end

--- a/app/controllers/users/unlocks_controller.rb
+++ b/app/controllers/users/unlocks_controller.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+class Users::UnlocksController < Devise::UnlocksController
+  # GET /resource/unlock/new
+  # def new
+  #   super
+  # end
+
+  # POST /resource/unlock
+  # def create
+  #   super
+  # end
+
+  # GET /resource/unlock?unlock_token=abcdef
+  # def show
+  #   super
+  # end
+
+  # protected
+
+  # The path used after sending unlock password instructions
+  # def after_sending_unlock_instructions_path_for(resource)
+  #   super(resource)
+  # end
+
+  # The path used after unlocking the resource
+  # def after_unlock_path_for(resource)
+  #   super(resource)
+  # end
+end

--- a/app/models/deliver_address.rb
+++ b/app/models/deliver_address.rb
@@ -1,0 +1,25 @@
+class DeliverAddress < ApplicationRecord
+  validates :post_code, :prefecture_code, :city,
+            :house_number, :destination_first_name,
+            :destination_family_name, :destination_first_name_kana,
+            :destination_family_name_kana, presence: true
+  validates :phone_number,                 uniqueness: { case_sensitive: false }
+  validates :phone_number,                 format: { with: /\A(\d{10,11})?\z/}
+  validates :post_code,                    format: { with: /\A\d{7}\z/ }
+  validates :destination_first_name, :destination_family_name,
+                                           format: { with: /\A[ぁ-んァ-ン一-龥]/ }
+  validates :destination_first_name_kana, :destination_family_name_kana,
+                                           format: { with: /\A[ァ-ヶー－]+\z/ }
+  belongs_to :user, optional: true
+
+  enum prefecture_code: {
+    北海道:1,青森県:2,岩手県:3,宮城県:4,秋田県:5,山形県:6,福島県:7,
+    茨城県:8,栃木県:9,群馬県:10,埼玉県:11,千葉県:12,東京都:13,神奈川県:14,
+    新潟県:15,富山県:16,石川県:17,福井県:18,山梨県:19,長野県:20,
+    岐阜県:21,静岡県:22,愛知県:23,三重県:24,
+    滋賀県:25,京都府:26,大阪府:27,兵庫県:28,奈良県:29,和歌山県:30,
+    鳥取県:31,島根県:32,岡山県:33,広島県:34,山口県:35,
+    徳島県:36,香川県:37,愛媛県:38,高知県:39,
+    福岡県:40,佐賀県:41,長崎県:42,熊本県:43,大分県:44,宮崎県:45,鹿児島県:46,沖縄県:47
+  }
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -7,4 +7,11 @@ class User < ApplicationRecord
             :first_name_kana, :family_name_kana,
             :birth_date, presence: true
   validates :email, uniqueness: true
+  validates :first_name, :family_name,
+            format: { with: /\A[ぁ-んァ-ン一-龥]/ }
+  validates :first_name_kana, :family_name_kana,
+            format: { with: /\A[ァ-ヶー－]+\z/ }
+  validates :birth_date, format: { with: /\A\d{1,4}(\/|-)\d{1,2}\1\d{1,2}\z/ }
+  has_one :deliver_address, dependent: :destroy
+  # accepts_nested_attributes_for :deliver_address
 end

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,87 +1,51 @@
 .SignupPage
   %header.Signup-header
     -# = render "layouts/header"
-
   %main.Signup-main
     %section.Signup-main__information
       %h2.Signup-main__information__title
         会員情報入力
       .Signup-main__information__form
         .FormField
-          %form
-            .FormField__content
-              %label ニックネーム
-              %span.FormField__content__require 必須
-              %br
-              %input.FormField__content__input{"type": "text", "placeholder": "例) フリマ太郎"}
-            .FormField__content
-              %label メールアドレス
-              %span.FormField__content__require 必須
-              %br
-              %input.FormField__content__input{"type": "text", "placeholder": "PC・携帯どちらでも可"}
-            .FormField__content
-              %label パスワード
-              %span.FormField__content__require 必須
-              %br
-              %input.FormField__content__input{"type": "text", "placeholder": "7文字以上の半角英数字"}
-              -# ↑例: f.password_field :password,
-            .FormField__content
-              %lavel パスワード(確認)
-              %span.FormField__content__require 必須
-              %br
-              %input.FormField__content__input{"type": "text", "placeholder": "7文字以上の半角英数字"}
-              -# ↑例: f.password_field :password_confirmation,
+          = form_with model: @user, local: true do |f|
+            = render 'devise/shared/error_messages', resource: resource
 
             .FormField__content
-              %lavel 名前(全角)
+              = f.label 'ニックネーム'
               %span.FormField__content__require 必須
               %br
-              %input.FormField__content__input--left{"type": "text", "size": "10", "placeholder": "例) 山田"}
-              %input.FormField__content__input--right{"type": "text", "size": "10", "placeholder": "例) 太郎"}
+              = f.text_field :nickname, class: "FormField__content__input", placeholder: "例) フリマ太郎"
             .FormField__content
-              %lavel 名前(ふりがな)
+              = f.label 'メールアドレス'
               %span.FormField__content__require 必須
               %br
-              %input.FormField__content__input--left{"type": "text", "size": "10", "placeholder": "例) ヤマダ"}
-              %input.FormField__content__input--right{"type": "text", "size": "10", "placeholder": "例) タロウ"}
+              = f.email_field :email, class: "FormField__content__input", placeholder: "PC・携帯どちらでも可"
             .FormField__content
-              %lavel 生年月日
+              = f.label 'パスワード'
               %span.FormField__content__require 必須
               %br
-              %input.FormField__content__birth__input--left{"type": "text", "size": "10"}
-              %input.FormField__content__birth__input--center{"type": "text", "size": "10"}
-              %input.FormField__content__birth__input--right{"type": "text", "size": "10"}
-              -# = f.date_select :birth_day, { use_month_numbers:true, prompt:"--", end_year:1900}
-
+              = f.password_field :password, class: "FormField__content__input", placeholder: "7文字以上の半角英数字"
             .FormField__content
-              %lavel 郵便番号
+              = f.label 'パスワード(確認)'
               %span.FormField__content__require 必須
               %br
-              %input.FormField__content__input{"type": "text", "placeholder": "例）810-0801"}
+              = f.password_field :password_confirmation, class: "FormField__content__input", placeholder: "7文字以上の半角英数字"
             .FormField__content
-              %lavel 都道府県
+              = f.label '名前(全角)'
               %span.FormField__content__require 必須
               %br
-              %input.FormField__content__input{"type": "text"}
+              = f.text_field :family_name, class: "FormField__content__input--left", size: "10", placeholder: "例) 山田"
+              = f.text_field :first_name, class: "FormField__content__input--right", size: "10", placeholder: "例) 太郎"
             .FormField__content
-              %lavel 市町村
+              = f.label '名前(フリガナ)'
               %span.FormField__content__require 必須
               %br
-              %input.FormField__content__input{"type": "text", "placeholder": "例) 福岡市"}
+              = f.text_field :family_name_kana, class: "FormField__content__input--left", size: "10", placeholder: "例) ヤマダ"
+              = f.text_field :first_name_kana, class: "FormField__content__input--right", size: "10", placeholder: "例) タロウ"
             .FormField__content
-              %lavel 番地
+              = f.label '生年月日'
               %span.FormField__content__require 必須
               %br
-              %input.FormField__content__input{"type": "text", "placeholder": "例) 博多区中洲5丁目4-18"}
-            .FormField__content
-              %lavel .建物名
-              %span.FormField__content__optional 任意
-              %br
-              %input.FormField__content__input{"type": "text", "placeholder": "例) 吉本ビル101"}
-            .FormField__content
-              %lavel 電話番号
-              %span.FormField__content__optional 任意
-              %br
-              %input.FormField__content__input{"type": "text", "placeholder": "例）090-XXXX-XXXX"}
+              != sprintf(f.date_select(:birth_date, use_month_numbers: true, prompt: "--", start_year:Time.now.year, end_year: 1920, class: "FormField__content__birth__input--left", date_separator: '%s'),'年','月')+'日'
             .FormField__content       
-              %input.SignUp-btn{"type": "submit", "value": "新規登録"}
+              = f.submit '次へ', class: "SignUp-btn", url: deliver_addresses_path

--- a/app/views/devise/registrations/new_deliver_address.html.haml
+++ b/app/views/devise/registrations/new_deliver_address.html.haml
@@ -1,0 +1,55 @@
+.SignupPage
+  %header.Signup-header
+    -# = render "layouts/header"
+  %main.Signup-main
+    %section.Signup-main__information
+      %h2.Signup-main__information__title
+        お届け先情報入力
+      .Signup-main__information__form
+        .FormField
+          = form_with model: @deliver_address, url: deliver_addresses_path, method: :post, local: true do |f|
+            = render 'devise/shared/error_messages', resource: @deliver_address
+            .FormField__content
+              = f.label '郵便番号(ハイフン(-)なし)'
+              %span.FormField__content__require 必須
+              %br
+              = f.text_field :post_code, class: "FormField__content__input", size: "7" ,placeholder: "例）8100801"
+            .FormField__content
+              = f.label '都道府県'
+              %span.FormField__content__require 必須
+              %br
+              = f.select :prefecture_code, DeliverAddress.prefecture_codes.keys.to_a, class: "FormField__content__input"
+            .FormField__content
+              = f.label '市町村'
+              %span.FormField__content__require 必須
+              %br
+              = f.text_field :city, class: "FormField__content__input", placeholder: "例) 福岡市"
+            .FormField__content
+              = f.label '番地'
+              %span.FormField__content__require 必須
+              %br
+              = f.text_field :house_number, class: "FormField__content__input", placeholder: "例) 博多区中洲5丁目4-18"
+            .FormField__content
+              = f.label '建物名'
+              %span.FormField__content__optional (任意)
+              %br
+              = f.text_field :building_name, class: "FormField__content__input", placeholder: "例) 吉本ビル101"
+            .FormField__content
+              = f.label '送付先氏名(全角)'
+              %span.FormField__content__require 必須
+              %br
+              = f.text_field :destination_family_name, class: "FormField__content__input--left", size: "10", placeholder: "例) 山田"
+              = f.text_field :destination_first_name, class: "FormField__content__input--right", size: "10", placeholder: "例) 太郎"
+            .FormField__content
+              = f.label '送付先氏名(フリガナ)'
+              %span.FormField__content__require 必須
+              %br
+              = f.text_field :destination_family_name_kana, class: "FormField__content__input--left", size: "10", placeholder: "例) ヤマダ"
+              = f.text_field :destination_first_name_kana, class: "FormField__content__input--right", size: "10", placeholder: "例) タロウ"
+            .FormField__content
+              = f.label '電話番号(ハイフン(-)なし)'
+              %span.FormField__content__optional 任意
+              %br
+              = f.text_field :phone_number, class: "FormField__content__input", size: "11" , placeholder: "例）090XXXXXXXX"
+            .FormField__content       
+              = f.submit '新規登録', class: "SignUp-btn", url: deliver_addresses_path

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -7,9 +7,9 @@
         ログイン
       .Login-main__information__form
         .FormField
-          %form
+          = form_with model: @user, url: user_session_path, local: true do |f|
             .FormField__adress
-              %input.input{"placeholder": "メールアドレス", "type": "text"}
+              = f.email_field :email, class: "input", placeholder: "メールアドレス"
             .FormField__password
-              %input.input{"placeholder": "パスワード", "type": "text"}
-            %input.Login-btn{"type": "submit", "value": "ログイン"}
+              = f.password_field :password, class: "input", placeholder: "パスワード"
+            = f.submit "ログイン", class: "Login-btn"

--- a/app/views/items/index.html.haml
+++ b/app/views/items/index.html.haml
@@ -1,2 +1,3 @@
 %h1 Items#index
 %p Find me in app/views/items/index.html.erb
+= link_to 'ログアウト', destroy_user_session_path, method: :delete

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -183,7 +183,8 @@ Devise.setup do |config|
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly
   # to give user feedback and not to assert the e-mail validity.
-  config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+  # config.email_regexp = /\A[^@\s]+@[^@\s]+\z/
+    config.email_regexp = /\A[\w+\-.]+@[a-z\d\-.]+\.[a-z]+\z/
 
   # ==> Configuration for :timeoutable
   # The time you want to timeout the user session without activity. After this

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,8 +1,14 @@
 Rails.application.routes.draw do
-  devise_for :users
+  devise_for :users, controllers: {
+    registrations: 'users/registrations'
+  }
+  devise_scope :user do
+    get 'deliver_addresses', to: 'users/registrations#new_deliver_address'
+    post 'deliver_addresses', to: 'users/registrations#create_deliver_address'
+  end
   root 'items#index'
   resources :users
-  resources :deliver_addresses, only: [:create, :update, :edit]
+  # resources :deliver_addresses, only: [:create, :update, :edit]
   resources :creditcards, only: [:create, :update, :edit]
   resources :brands, only: [:create]
   resources :products do 

--- a/db/migrate/20200723132716_create_deliver_addresses.rb
+++ b/db/migrate/20200723132716_create_deliver_addresses.rb
@@ -1,0 +1,19 @@
+class CreateDeliverAddresses < ActiveRecord::Migration[6.0]
+  def change
+    create_table :deliver_addresses do |t|
+      t.integer    :post_code,                    null: false
+      t.integer    :prefecture_code,              null: false
+      t.string     :city,                         null: false
+      t.string     :house_number,                 null: false
+      t.string     :building_name
+      t.integer    :phone_number,                 unique: true
+      t.references :user,                         null: false, foreign_key: true
+      t.string     :destination_first_name,       null: false
+      t.string     :destination_family_name,      null: false
+      t.string     :destination_first_name_kana,  null: false
+      t.string     :destination_family_name_kana, null: false
+      t.timestamps
+    end
+    add_index :deliver_addresses, :phone_number,  unique: true
+  end
+end

--- a/db/migrate/20200724162920_change_data_post_code_phone_number_to_deliver_address.rb
+++ b/db/migrate/20200724162920_change_data_post_code_phone_number_to_deliver_address.rb
@@ -1,0 +1,6 @@
+class ChangeDataPostCodePhoneNumberToDeliverAddress < ActiveRecord::Migration[6.0]
+  def change
+    change_column :deliver_addresses, :post_code, :string
+    change_column :deliver_addresses, :phone_number, :string
+  end
+end

--- a/db/migrate/20200725141357_add_user_id_to_deliver_addresses.rb
+++ b/db/migrate/20200725141357_add_user_id_to_deliver_addresses.rb
@@ -1,0 +1,5 @@
+class AddUserIdToDeliverAddresses < ActiveRecord::Migration[6.0]
+  def change
+    add_reference :deliver_addresses, :user, foreign_key: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,27 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_07_22_101453) do
+ActiveRecord::Schema.define(version: 2020_07_25_141357) do
+
+  create_table "deliver_addresses", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
+    t.string "post_code", null: false
+    t.integer "prefecture_code", null: false
+    t.string "city", null: false
+    t.string "house_number", null: false
+    t.string "building_name"
+    t.string "phone_number"
+    t.string "destination_first_name", null: false
+    t.string "destination_family_name", null: false
+    t.string "destination_first_name_kana", null: false
+    t.string "destination_family_name_kana", null: false
+    t.datetime "created_at", precision: 6, null: false
+    t.datetime "updated_at", precision: 6, null: false
+    t.bigint "user_id"
+    t.index ["phone_number"], name: "index_deliver_addresses_on_phone_number", unique: true
+    t.index ["user_id"], name: "index_deliver_addresses_on_user_id"
+  end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-
     t.string "nickname", null: false
     t.string "email", null: false
     t.string "encrypted_password", null: false
@@ -24,7 +41,6 @@ ActiveRecord::Schema.define(version: 2020_07_22_101453) do
     t.date "birth_date", null: false
     t.text "introduction"
     t.string "icon"
-    
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"
@@ -34,4 +50,5 @@ ActiveRecord::Schema.define(version: 2020_07_22_101453) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true
   end
 
+  add_foreign_key "deliver_addresses", "users"
 end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,4 +1,5 @@
 FactoryBot.define do
+
   
   factory :user do
     nickname                { "tarou" }

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -62,4 +62,3 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
-end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -96,4 +96,5 @@ RSpec.configure do |config|
   # as the one that triggered the failure.
   Kernel.srand config.seed
 =end
+
 end


### PR DESCRIPTION
# What
新規登録・ログイン機構を実装。都道府県の入力を簡略化する為、enumを利用したハッシュをDeliverAddressモデルに作成。
郵便番号、電話番号のデータ型をstringに修正。いくつかのバリデーションを追加した。
hamlファイル内のformタグをform_withメソッドに書き換え、DeliverAddressモデルのデータをfields_forタグを用いてUserモデルデータと同時に送信する機構を実装。
deviseコントローラー内でオーバーライド、buildメソッドと２種類のストロングパラメーターを使用し、両テーブルにデータを保存する仕組みを実装した。
利便性を向上させう目的でウィザード形式による登録機能を実装した。
仮設のビューを作成、ログイン、ログアウトの機能を実装。
遷移先のビューをルートパスであるitemsコントローラーのindexアクションに設定し、ユーザー登録機構を完成。

なお、テストコードは別ブランチで分けてあり、LGTMを受けている。

# Why
本アプリケーションにおけるメイン機能をユーザーが利用可能にするため。