### PR TITLE
商品テーブルにカラムの追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,6 +105,8 @@
 |prep_date|string|null: false|
 |size|references|foreign_key: true|
 |shipping_fee|integer|null: false|
+|prefecture_code|integer|null: false|
+|postage_payer|string|null: false|
 ### Association
 - has_many :photos, dependent: :destroy
 - has_many :comments, dependent: :destroy


### PR DESCRIPTION
#what
商品テーブルに地域と送料支払い者のカラムを追加
#why
商品取引の際、配送料だけではどこに運んで誰が支払うかが分からないため。