### PR TITLE
商品情報編集ページの実装

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,6 +25,7 @@
 
 /public/packs
 /public/packs-test
+/public/uploads
 /node_modules
 /yarn-error.log
 yarn-debug.log*

--- a/app/assets/javascripts/category.js
+++ b/app/assets/javascripts/category.js
@@ -31,7 +31,8 @@ $(function() {
     .done(function(children) {
       $('#category_child').remove();
       $('#category_grandchild').remove();
-      $('#size-field').attr('style', 'display: none;');
+      $('#size-field-new').attr('style', 'display: none;');
+      $('#size-field-edit').attr('style', 'display: none;');
       let insertHTML = '';
         $.each(children, function(i, child) {
           insertHTML += appendOption(child);
@@ -41,7 +42,8 @@ $(function() {
     .fail(function() {
       $('#category_child').remove();
       $('#category_grandchild').remove();
-      $('#size-field').attr('style', 'display: none;');
+      $('#size-field-new').attr('style', 'display: none;');
+      $('#size-field-edit').attr('style', 'display: none;');
     })
   });
 
@@ -55,7 +57,8 @@ $(function() {
     })
     .done(function(grandChildren) {
       $('#category_grandchild').remove();
-      $('#size-field').attr('style', 'display: none;');
+      $('#size-field-new').attr('style', 'display: none;');
+      $('#size-field-edit').attr('style', 'display: none;');
       let insertHTML = '';
         $.each(grandChildren, function(i, grandChild) {
           insertHTML += appendOption(grandChild);
@@ -64,15 +67,18 @@ $(function() {
     })
     .fail(function() {
       $('#category_grandchild').remove();
-      $('#size-field').attr('style', 'display: none;');
+      $('#size-field-new').attr('style', 'display: none;');
+      $('#size-field-edit').attr('style', 'display: none;');
     })
   });
 
   $(document).on('change', '#category_grandchild', function() {
     if ($(this).val() == '---') {
-      $('#size-field').attr('style', 'display: none;');
+      $('#size-field-new').attr('style', 'display: none;');
+      $('#size-field-edit').attr('style', 'display: none;');
     } else {
-      $('#size-field').attr('style', 'display: block;');
+      $('#size-field-new').attr('style', 'display: block;');
+      $('#size-field-edit').attr('style', 'display: block;');
     };
   });
 });

--- a/app/assets/javascripts/photo.js
+++ b/app/assets/javascripts/photo.js
@@ -1,7 +1,7 @@
 $(function() {
-  $('label[class=file-label]').after('<div class="fileimg" style="display: flex;flex-wrap: wrap;"><div/>');
+  // $('label[class=file-label]').after('<div class="fileimg" style="display: flex;flex-wrap: wrap;"><div/>');
 
-  img_count = 0
+  img_count = 0 + $('.ProductsNew__main__form__group__field__file-input__prevbox__image').length
   img_index = 0
   $('.file-label').on('click', function() {
     $('.fileinput').change(function() {
@@ -21,7 +21,7 @@ $(function() {
           let img_src = $('<img style="width: 7rem;height: 7rem;">').attr('src', reader.result);
           let box = $(`<div class="fileinput${img_index - 1}" style="margin-bottom: 0.3rem;background: whitesmoke;display: flex;flex-direction: column;justify-content: center;align-items: center;"></div>`);
           let box2 =  box.append(img_src).append('<p class="deletefile" style="margin: 0;padding: 0.2rem;color: #4897d8;font-size: 0.9rem;font-weight: normal;cursor: pointer;">削除</p>');
-          $('.fileimg').append(box2);
+          $('.ProductsNew__main__form__group__field__file-input__prevbox').append(box2);
         }
         reader.readAsDataURL(file);
         label.attr('for', `filearea${img_index + 1}`);

--- a/app/assets/javascripts/photo.js
+++ b/app/assets/javascripts/photo.js
@@ -1,5 +1,4 @@
 $(function() {
-  // $('label[class=file-label]').after('<div class="fileimg" style="display: flex;flex-wrap: wrap;"><div/>');
 
   img_count = 0 + $('.ProductsNew__main__form__group__field__file-input__prevbox__image').length
   img_index = 0

--- a/app/assets/stylesheets/products_new.scss
+++ b/app/assets/stylesheets/products_new.scss
@@ -97,6 +97,33 @@
             height: auto;
             margin-top: 1rem;
 
+            &__prevbox {
+              display: flex;
+              flex-wrap: wrap;
+
+              &__image {
+                margin-bottom: 0.3rem;
+                background: $color_item2;
+                display: flex;
+                flex-direction: column;
+                justify-content: center;
+                align-items: center;
+
+                img {
+                  width: 7rem;
+                  height: 7rem;
+                }
+
+                p {
+                  margin: 0;
+                  padding: 0.2rem;
+                  color: #4897d8;
+                  font-size: 0.9rem;
+                  font-weight: normal;
+                  cursor: pointer;
+                }
+              }
+            }
             div#files {
               width: 100%;
               height: auto;
@@ -136,6 +163,15 @@
             flex-direction: column;
             justify-content: center;
             align-items: center;
+
+            select {
+              width: 100%;
+              height: 3.5rem;
+              margin-top: 1rem;
+              padding: 0 0.8rem;
+              border: 1px solid #dbdbdb;
+              border-radius: 0.2rem;
+            }
           }
 
           &__price-input {
@@ -233,8 +269,7 @@
             border-radius: 50%;
           }
         }
-
-        #size-field {
+        #size-field-new {
           display: none;
         }
       }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -32,9 +32,10 @@ class ProductsController < ApplicationController
     @parent = @child.parent
     @grandchildren = @child.children
     @children = @child.parent.children
-    @photos =  @product.photos.build
-    @brand = @product.build_brand
     @prev_images = @product.photos.order(created_at: "ASC")
+    @photos =  @product.photos.build
+    @brand_name = @product.brand.name
+    @brand = @product.build_brand
   end
 
   def search_category_children

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -24,6 +24,19 @@ class ProductsController < ApplicationController
     redirect_to user_path(current_user)
   end
 
+  def edit
+    @product = Product.find(params[:id])
+    @parents = Category.where(ancestry: nil).order(id: "ASC")
+    @grandchild = Category.find(@product.category_id)
+    @child = @grandchild.parent
+    @parent = @child.parent
+    @grandchildren = @child.children
+    @children = @child.parent.children
+    @photos =  @product.photos.build
+    @brand = @product.build_brand
+    @prev_images = @product.photos.order(created_at: "ASC")
+  end
+
   def search_category_children
     respond_to do |format|
       format.html

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -31,7 +31,7 @@ class ProductsController < ApplicationController
     @child = @grandchild.parent
     @parent = @child.parent
     @grandchildren = @child.children
-    @children = @child.parent.children
+    @children = @parent.children
     @prev_images = @product.photos.order(created_at: "ASC")
     @photos =  @product.photos.build
     @brand_name = @product.brand.name

--- a/app/uploaders/image_uploader.rb
+++ b/app/uploaders/image_uploader.rb
@@ -39,9 +39,9 @@ class ImageUploader < CarrierWave::Uploader::Base
 
   # Add a white list of extensions which are allowed to be uploaded.
   # For images you might use something like this:
-  # def extension_whitelist
-  #   %w(jpg jpeg gif png)
-  # end
+  def extension_whitelist
+    %w(jpg jpeg gif png)
+  end
 
   # Override the filename of the uploaded files:
   # Avoid using model.id or version_name here, see uploader/store.rb for details.

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -53,7 +53,7 @@
             = brand.label "ブランド", class: "field-label"
             %span.optional 任意
             .ProductsNew__main__form__group__field__input
-              = brand.text_field :name, placeholder: '例) シャネル'
+              = brand.text_field :name, value: @brand_name, placeholder: '例) シャネル'
         .ProductsNew__main__form__group__field
           = product.label '商品の状態', class: "field-label"
           %span 必須

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -94,7 +94,7 @@
                 = product.number_field :price, placeholder: "0"
           .ProductsNew__main__form__group__field
             .ProductsNew__main__form__group__field__button
-              = product.submit '出品する'
+              = product.submit '更新する'
           .ProductsNew__main__form__group__field__link
             = link_to 'もどる', '#'
   .ProductsNew__footer

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -1,0 +1,112 @@
+.ProductsNew
+  .ProductsNew__header
+    = link_to image_tag('logo.png'), products_path
+  .ProductsNew__main
+    = form_with model: @product, url: products_path, class: "ProductsNew__main__form", local: true do |product|
+      = render 'devise/shared/error_messages', resource: @product
+      .ProductsNew__main__form__group
+        = product.fields_for :photos, @photos do |photo|
+          .ProductsNew__main__form__group__field
+            %label.field-label 出品画像
+            %span 必須
+            %h3 最大10枚までアップロードできます
+            .ProductsNew__main__form__group__field__file-input
+              #files
+                = photo.file_field :image, id: "filearea", class: "fileinput fileinput0"
+                %label{class: "file-label", for: "filearea"}
+                  = icon('fa', 'camera')
+                  %p クリックしてファイルをアップロード
+                .ProductsNew__main__form__group__field__file-input__prevbox
+                  - @prev_images.each do |prev_image|
+                    .ProductsNew__main__form__group__field__file-input__prevbox__image
+                      = image_tag prev_image.image.url
+                      %p 削除
+
+      .ProductsNew__main__form__group
+        .ProductsNew__main__form__group__field
+          = product.label '商品名', class: "field-label"
+          %span 必須
+          .ProductsNew__main__form__group__field__input
+            = product.text_field :name, placeholder: '40文字まで'
+        .ProductsNew__main__form__group__field
+          = product.label '商品の説明', class: "field-label"
+          %span 必須
+          .ProductsNew__main__form__group__field__input
+            = product.text_area :introduction, maxlength: "1000", placeholder: "商品の説明(必須1,000文字以内)(色、素材、重さ、定価、注意点など)例) 2010年頃に1万円で購入したジャケットです。ライトグレーで傷はありません。あわせやすいのでおすすめです。"
+
+      .ProductsNew__main__form__group
+        .ProductsNew__main__form__group__field
+          %p 商品の詳細
+          = product.label 'カテゴリー', class: "field-label"
+          %span 必須
+          .ProductsNew__main__form__group__field__category-input
+            = product.collection_select :category_id, @parents, :id, :name, { selected: @parent.id, prompt: '---' }, { id: 'category_parent' }
+            = product.collection_select :category_id, @children, :id, :name, { selected: @child.id, prompt: '---' }, { id: 'category_child' }
+            = product.collection_select :category_id, @grandchildren, :id, :name, { selected: @grandchild.id, prompt: '---' }, { id: 'category_grandchild' }
+        .ProductsNew__main__form__group__field#size-field-edit
+          = product.label 'サイズ', class: "field-label"
+          %span 必須
+          .ProductsNew__main__form__group__field__input
+            = product.collection_select :size_id, Size.all, :id, :name, prompt: '---'
+        .ProductsNew__main__form__group__field   
+          = product.fields_for :brand, @brand do |brand|
+            = brand.label "ブランド", class: "field-label"
+            %span.optional 任意
+            .ProductsNew__main__form__group__field__input
+              = brand.text_field :name, placeholder: '例) シャネル'
+        .ProductsNew__main__form__group__field
+          = product.label '商品の状態', class: "field-label"
+          %span 必須
+          .ProductsNew__main__form__group__field__input
+            = product.collection_select :condition_id, Condition.all, :id, :name, prompt: '---'
+          
+        .ProductsNew__main__form__group
+          .ProductsNew__main__form__group__field
+            %p
+              配送について
+              = link_to '？', '#', class: "help"
+            = product.label '配送料の負担', class: "field-label"
+            %span 必須
+            .ProductsNew__main__form__group__field__input
+              = product.collection_select :postage_payer_id, PostagePayer.all, :id, :name, prompt: '---'
+          .ProductsNew__main__form__group__field
+            = product.label '発送元の地域', class: "field-label"
+            %span 必須
+            .ProductsNew__main__form__group__field__input
+              = product.select :prefecture_code, Product.prefecture_codes.keys.to_a, prompt: '---'
+          .ProductsNew__main__form__group__field
+            = product.label '発送までの日数', class: "field-label"
+            %span 必須
+            .ProductsNew__main__form__group__field__input
+              = product.collection_select :prep_date_id, PrepDate.all, :id, :name, prompt: '---'
+
+        .ProductsNew__main__form__group
+          .ProductsNew__main__form__group__field
+            %p
+              価格(￥300〜9,999,999)
+              = link_to '？', '#', class: "help"
+            .ProductsNew__main__form__group__field__price-input
+              .ProductsNew__main__form__group__field__price-input__label
+                = product.label '販売価格', class: "field-label"
+                %span 必須
+              .ProductsNew__main__form__group__field__price-input__value
+                %span.price ￥
+                = product.number_field :price, placeholder: "0"
+          .ProductsNew__main__form__group__field
+            .ProductsNew__main__form__group__field__button
+              = product.submit '出品する'
+          .ProductsNew__main__form__group__field__link
+            = link_to 'もどる', '#'
+  .ProductsNew__footer
+    .ProductsNew__footer__links
+      %ul
+        %li
+          = link_to 'プライバシーポリシー', '#'
+        %li
+          = link_to 'furima利用規約', '#'
+        %li
+          = link_to '特定商取引に関する表記', '#'
+    .ProductsNew__footer__logo
+      = link_to image_tag('logo-white.png'), products_path
+    .ProductsNew__footer__caption
+      %p © Furima, Inc.

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -16,6 +16,7 @@
                 %label{class: "file-label", for: "filearea"}
                   = icon('fa', 'camera')
                   %p クリックしてファイルをアップロード
+                .ProductsNew__main__form__group__field__file-input__prevbox
 
       .ProductsNew__main__form__group
         .ProductsNew__main__form__group__field
@@ -36,7 +37,7 @@
           %span 必須
           .ProductsNew__main__form__group__field__category-input
             = product.collection_select :category_id, @parents, :id, :name, {prompt: '---'}, {id: 'category_parent'}
-        .ProductsNew__main__form__group__field#size-field
+        .ProductsNew__main__form__group__field#size-field-new
           = product.label 'サイズ', class: "field-label"
           %span 必須
           .ProductsNew__main__form__group__field__input


### PR DESCRIPTION
# What
商品情報編集ページの見た目を実装。
すでに登録されている情報は編集画面を開いた時点で表示されるよう実装した。

# Why
商品情報編集機能の実装を効率的に行うため。

<img width="1186" alt="ca58013ba5ec5a6e4f15086fc3c13d04 (1)" src="https://user-images.githubusercontent.com/65937890/89184134-4a532480-d5d3-11ea-8ca2-994a4e39cb78.png">

<img width="1438" alt="b5591fb880ecb8f300b73502ebdb448c" src="https://user-images.githubusercontent.com/65937890/89184187-59d26d80-d5d3-11ea-8bf7-c2e965d64913.png">

<img width="1428" alt="648ac3ae657174a1addbb971a5908ac5" src="https://user-images.githubusercontent.com/65937890/89184196-5fc84e80-d5d3-11ea-995f-1f68f57cc57b.png">

<img width="1432" alt="99402072358cfc1352dc192e4b2e4667" src="https://user-images.githubusercontent.com/65937890/89184209-62c33f00-d5d3-11ea-8f16-a45d4ab8585c.png">


