### PR TITLE
商品出品機能の修正

### DIFF
--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -4,7 +4,7 @@ class ProductsController < ApplicationController
   before_action :adimn_seller, only: [:edit, :destroy]
 
   def index
-    @products = Product.includes(:photos).order(created_at: :desc).first(5)
+    @products = Product.includes(:photos).order(created_at: :desc).limit(5)
   end
 
   def new
@@ -28,6 +28,9 @@ class ProductsController < ApplicationController
 
   def create
     @product = Product.new(product_params)
+    unless @product.brand.valid?
+      @product.brand.destroy
+    end
     unless @product.valid?
       flash.now[:alert] = @product.errors.full_messages
       @parents = Category.where(ancestry: nil).order(id: "ASC")

--- a/app/models/photo.rb
+++ b/app/models/photo.rb
@@ -1,6 +1,5 @@
 class Photo < ApplicationRecord
   validates :image, presence: true
-  validates :product, presence: true
-  mount_uploader :images, ImageUploader
+  mount_uploader :image, ImageUploader
   belongs_to :product, optional: true
 end

--- a/db/migrate/20200806022610_remove_foreign_key_from_products.rb
+++ b/db/migrate/20200806022610_remove_foreign_key_from_products.rb
@@ -1,0 +1,5 @@
+class RemoveForeignKeyFromProducts < ActiveRecord::Migration[6.0]
+  def change
+    remove_foreign_key :products, :brands
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2020_08_02_094650) do
+ActiveRecord::Schema.define(version: 2020_08_06_022610) do
 
   create_table "brands", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
     t.string "name", null: false
@@ -82,7 +82,6 @@ ActiveRecord::Schema.define(version: 2020_08_02_094650) do
   end
 
   create_table "users", options: "ENGINE=InnoDB DEFAULT CHARSET=utf8", force: :cascade do |t|
-
     t.string "nickname", null: false
     t.string "email", null: false
     t.string "encrypted_password", null: false
@@ -105,6 +104,5 @@ ActiveRecord::Schema.define(version: 2020_08_02_094650) do
   add_foreign_key "credit_cards", "users"
   add_foreign_key "deliver_addresses", "users"
   add_foreign_key "photos", "products"
-  add_foreign_key "products", "brands"
   add_foreign_key "products", "categories"
 end


### PR DESCRIPTION
# What
商品出品機能を修正した。
productsテーブルのbrand_idは必須でないため、外部キー制約を削除。
brandの保存はproductsレコードの保存時に同時に実行され、その時点でbrandのnameカラムが有効でない場合保存に失敗しエラーが起きるため、productsレコードの保存前にbrandが有効かどうかを検証し、有効でなければインスタンス自体を削除するという機能を実装した。

photosテーブルについてはmount_uploaderのカラム名の指定がimaagesと間違っていたので、imageに修正した。

# Why
正しく動作させるため。