### PR TITLE
画像追加・削除機能の実装

### DIFF
--- a/app/assets/javascripts/photo.js
+++ b/app/assets/javascripts/photo.js
@@ -1,75 +1,79 @@
-$(function () {
-  img_count =
-    0 +
-    $(".ProductsNew__main__form__group__field__file-input__prevbox__image")
-      .length;
-  img_index = 0;
-  $(".file-label").on("click", function () {
-    $(".fileinput").change(function () {
+$(function() {
+  function displayButton() {
+    $(".deletefile").attr("style", "display: block;");
+    $(".deleteprev").attr("style", "display: block;");
+  };
+  function hiddenButton() {
+    $(".deletefile").attr("style", "display: none;");
+    $(".deleteprev").attr("style", "display: none;");
+  };
+  function buildInput(label, input_count) {
+    label.attr("for", `filearea${input_count + 1}`);
+    label.before(`<input name="product[photos_attributes][${input_count + 1}][image]" id="filearea${input_count + 1}" type="file" class="fileinput fileinput${input_count + 1}" style="display: none;">`);
+  };
+
+  img_count = 0 + $(".prev_count").length;
+  input_count = 0 + $(".prev_count").length;
+  if (img_count == 10) {
+    $("#files").find("label").attr("style", "display: none;");
+  } else if (img_count == 1) {
+    $(".deleteprev").attr('style', 'display: none;');
+  };
+
+  $(".file-label").on("click", function() {
+    $(".fileinput").change(function() {
       let label = $("#files").find("label");
       let file = $(this).prop("files")[0];
 
       if (!file.type.match("image.*")) {
         alert("この形式のファイルはアップロードできません");
         $(this).remove();
-        label.attr("for", `filearea${img_index + 1}`);
-        label.before(
-          `<input name="product[photos_attributes][${
-            img_index + 1
-          }][image]" id="filearea${
-            img_index + 1
-          }" type="file" class="fileinput fileinput${
-            img_index + 1
-          }" style="display: none;">`
-        );
-        img_index += 1;
+        buildInput(label, input_count);
+        input_count += 1;
         return;
       } else {
         let reader = new FileReader();
-        reader.onload = function () {
-          let img_src = $('<img style="width: 7rem;height: 7rem;">').attr(
-            "src",
-            reader.result
-          );
-          let box = $(
-            `<div class="fileinput${
-              img_index - 1
-            }" style="margin-bottom: 0.3rem;background: whitesmoke;display: flex;flex-direction: column;justify-content: center;align-items: center;"></div>`
-          );
-          let box2 = box
-            .append(img_src)
-            .append(
-              '<p class="deletefile" style="margin: 0;padding: 0.2rem;color: #4897d8;font-size: 0.9rem;font-weight: normal;cursor: pointer;">削除</p>'
-            );
-          $(
-            ".ProductsNew__main__form__group__field__file-input__prevbox"
-          ).append(box2);
+        reader.onload = function() {
+          let img_src = $('<img style="width: 7rem;height: 7rem;">').attr("src", reader.result);
+          let box = $(`<div class="fileinput${input_count - 1}" style="margin-bottom: 0.3rem;background: whitesmoke;display: flex;flex-direction: column;justify-content: center;align-items: center;"></div>`);
+          let box2 = box.append(img_src).append('<p class="deletefile" style="margin: 0;padding: 0.2rem;color: #4897d8;font-size: 0.9rem;font-weight: normal;cursor: pointer;">削除</p>');
+          $(".prev_box").append(box2);
         };
         reader.readAsDataURL(file);
-        label.attr("for", `filearea${img_index + 1}`);
-        label.before(
-          `<input name="product[photos_attributes][${
-            img_index + 1
-          }][image]" id="filearea${
-            img_index + 1
-          }" type="file" class="fileinput fileinput${
-            img_index + 1
-          }" style="display: none;">`
-        );
+        buildInput(label, input_count);
         img_count += 1;
-        img_index += 1;
+        input_count += 1;
         if (img_count == 10) {
           label.attr("style", "display: none;");
+        }
+        if(img_count == 2) {
+          displayButton();
         }
       }
     });
   });
 
-  $(document).on("click", ".deletefile", function () {
+  $(document).on("click", ".deletefile", function() {
     boxClass = $(this).parent().prop("class");
     $(`.${boxClass}`).remove();
     if (img_count == 10) {
       $(".file-label").attr("style", "display: flex;");
+    }
+    if (img_count == 2) {
+      hiddenButton();
+    }
+    img_count -= 1;
+  });
+
+  $(".deleteprev").on("click", function() {
+    let checkBox = $(this).parent().next();
+    checkBox.prop('checked', true);
+    $(this).parent().remove();
+    if (img_count == 10) {
+      $(".file-label").attr("style", "display: flex;");
+    }
+    if (img_count == 2) {
+      hiddenButton();
     }
     img_count -= 1;
   });

--- a/app/views/products/edit.html.haml
+++ b/app/views/products/edit.html.haml
@@ -12,15 +12,16 @@
             %h3 最大10枚までアップロードできます
             .ProductsNew__main__form__group__field__file-input
               #files
-                = photo.file_field :image, id: "filearea", class: "fileinput fileinput0"
-                %label{class: "file-label", for: "filearea"}
+                = photo.file_field :image, name: "product[photos_attributes][#{@prev_images.count}][image]", id: "filearea#{@prev_images.count}", class: "fileinput fileinput#{@prev_images.count}"
+                %label{class: "file-label", for: "filearea#{@prev_images.count}"}
                   = icon('fa', 'camera')
                   %p クリックしてファイルをアップロード
-                .ProductsNew__main__form__group__field__file-input__prevbox
+                .ProductsNew__main__form__group__field__file-input__prevbox.prev_box
                   - @prev_images.each do |prev_image|
-                    .ProductsNew__main__form__group__field__file-input__prevbox__image
+                    .ProductsNew__main__form__group__field__file-input__prevbox__image.prev_count
                       = image_tag prev_image.image.url
-                      %p 削除
+                      %p.deleteprev 削除
+                    = check_box_tag :"destroy_photo_id[]", prev_image.id
 
       .ProductsNew__main__form__group
         .ProductsNew__main__form__group__field


### PR DESCRIPTION
# What
商品情報編集機能において、画像を変更・削除できる機能を追加した。
元から登録されている画像を含め全ての画像がプレビュー表示され、各プレビューに削除ボタンが付くように実装。
画像が０枚にならないよう、プレビュー数が１枚になると削除ボタンは非表示になる。
元々登録されている画像のプレビューを削除して更新ボタンを押すとDB上からも削除され、編集ページ上新たに追加した画像は、新たに商品の画像として登録される。
元々ある画像を削除せずに更新ボタンを押すと、DB上からは削除されずにそのまま残る。

商品編集機能においては、既に登録されている情報はそのまま表示され、更新も正常に動作しており、以上の機能を追加した事で、商品編集機能を完成した。

なお、テストコードは別ブランチでLGTMを受けている。

# Why
商品画像の追加・変更をユーザーが自由に行えるようにする為。
![q2kjl-7w133](https://user-images.githubusercontent.com/65937890/89702012-ab824b80-d977-11ea-8ea6-03953d553fc2.gif)

![a8x7u-xyu2m](https://user-images.githubusercontent.com/65937890/89702018-b3da8680-d977-11ea-82cb-fed6204ac1a4.gif)

![d6j0s-kjvyc](https://user-images.githubusercontent.com/65937890/89702025-bc32c180-d977-11ea-863c-2842ee0f3753.gif)
