### PR TITLE
カテゴリ表示機能の実装

### DIFF
--- a/app/assets/stylesheets/modules/products.scss
+++ b/app/assets/stylesheets/modules/products.scss
@@ -588,7 +588,7 @@
 }
 
 .exhibition {
-  .link {
+  .exhibition__link {
     .exhibition_btn {
       width: 120px;
       background: #3ccace;

--- a/app/assets/stylesheets/products_details.scss
+++ b/app/assets/stylesheets/products_details.scss
@@ -5,7 +5,7 @@
   &__show{
     padding: 40px;
     margin: 0 auto;
-    .contents{
+    .show__contents{
       width: 700px;
       margin: auto;
         .itemBox{
@@ -122,7 +122,7 @@
           }
         }
       }
-      .links{
+      .show__links{
         height: 24px;
         font-weight: bold;
         .linksPage{
@@ -186,5 +186,11 @@
           }
         }
       }
+    }
+  }
+  .contents__cont {
+    a {
+      color: $color_item3;
+      text-decoration: none;
     }
   }

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -14,9 +14,7 @@ class ProductsController < ApplicationController
     @grandchild = Category.find(@product.category_id)
     @child = @grandchild.parent
     @parent = @child.parent
-    @parent_category_products = @products.select do |product|
-      product.category.parent.parent.name == @parent.name
-    end
+    @parent_category_products = @products.select { |product| product.category.parent.parent.name == @parent.name }
     @user = current_user
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -8,6 +8,13 @@ class ProductsController < ApplicationController
   end
 
   def show
+    @products = Product.all
+    @prev_product = @products.where("id < ?", @product.id).last
+    @next_product = @products.where("id > ?", @product.id).first
+    @grandchild = Category.find(@product.category_id)
+    @child = @grandchild.parent
+    @parent = @child.parent
+    @parent_category_products = @products.where(category_id: @parent.id).limit(3)
     @user = current_user
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -9,8 +9,8 @@ class ProductsController < ApplicationController
 
   def show
     @products = Product.all
-    @prev_product = @products.where("id < ?", @product.id).last
-    @next_product = @products.where("id > ?", @product.id).first
+    @prev_product = Product.prev_search(@product)
+    @next_product = Product.next_search(@product)
     @grandchild = Category.find(@product.category_id)
     @child = @grandchild.parent
     @parent = @child.parent

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -25,7 +25,7 @@ class ProductsController < ApplicationController
 
   def new
     @product = Product.new
-    @parents = Category.where(ancestry: nil).order(id: "ASC")
+    @parents = Category.set_parents
     @photos =  @product.photos.build
     @brand = @product.build_brand
   end
@@ -48,7 +48,7 @@ class ProductsController < ApplicationController
     end
     unless @product.valid?
       flash.now[:alert] = @product.errors.full_messages
-      @parents = Category.where(ancestry: nil).order(id: "ASC")
+      @parents = Category.set_parents
       @photos =  @product.photos.build
       @brand = @product.build_brand
       render :new and return
@@ -72,7 +72,7 @@ class ProductsController < ApplicationController
         redirect_to user_path(current_user)
       else
         flash.now[:alert] = @product.errors.full_messages
-        @parents = Category.where(ancestry: nil).order(id: "ASC")
+        @parents = Category.set_parents
         @grandchild = Category.find(@product.category_id)
         @child = @grandchild.parent
         @parent = @child.parent
@@ -104,7 +104,7 @@ class ProductsController < ApplicationController
         redirect_to user_path(current_user)
       else
         flash.now[:alert] = @product.errors.full_messages
-        @parents = Category.where(ancestry: nil).order(id: "ASC")
+        @parents = Category.set_parents
         @grandchild = Category.find(@product.category_id)
         @child = @grandchild.parent
         @parent = @child.parent
@@ -124,7 +124,7 @@ class ProductsController < ApplicationController
     
 
   def edit
-    @parents = Category.where(ancestry: nil).order(id: "ASC")
+    @parents = Category.set_parents
     @grandchild = Category.find(@product.category_id)
     @child = @grandchild.parent
     @parent = @child.parent

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -14,8 +14,9 @@ class ProductsController < ApplicationController
     @grandchild = Category.find(@product.category_id)
     @child = @grandchild.parent
     @parent = @child.parent
-    @parent_category_products = @products.select { |product|
-      product.category.parent.parent.name == @parent.name }
+    @parent_category_products = @products.select do |product|
+      product.category.parent.parent.name == @parent.name
+    end
     @user = current_user
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -14,7 +14,12 @@ class ProductsController < ApplicationController
     @grandchild = Category.find(@product.category_id)
     @child = @grandchild.parent
     @parent = @child.parent
-    @parent_category_products = @products.where(category_id: @parent.id).limit(3)
+    @parent_category_products = []
+    @products.each do |product|
+      if product.category.parent.parent.name == @parent.name
+        @parent_category_products << product
+      end
+    end
     @user = current_user
   end
 

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -14,11 +14,8 @@ class ProductsController < ApplicationController
     @grandchild = Category.find(@product.category_id)
     @child = @grandchild.parent
     @parent = @child.parent
-    @parent_category_products = []
-    @products.each do |product|
-      if product.category.parent.parent.name == @parent.name
-        @parent_category_products << product
-      end
+    @parent_category_products = @products.select do |product|
+      product.category.parent.parent.name == @parent.name
     end
     @user = current_user
   end

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -14,9 +14,8 @@ class ProductsController < ApplicationController
     @grandchild = Category.find(@product.category_id)
     @child = @grandchild.parent
     @parent = @child.parent
-    @parent_category_products = @products.select do |product|
-      product.category.parent.parent.name == @parent.name
-    end
+    @parent_category_products = @products.select { |product|
+      product.category.parent.parent.name == @parent.name }
     @user = current_user
   end
 

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -2,4 +2,8 @@ class Category < ApplicationRecord
   validates :name, presence: true
   has_many :products, dependent: :destroy
   has_ancestry
+
+  def self.set_parents
+    Category.where(ancestry: nil).order(id: "ASC")
+  end
 end

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -34,4 +34,12 @@ class Product < ApplicationRecord
   enum trading_status: {
     出品中:1,売却済み:2
   }
+
+  def self.prev_search(product)
+    Product.where("id < ?", product.id).last
+  end
+
+  def self.next_search(product)
+    Product.where("id > ?", product.id).first
+  end
 end

--- a/app/views/products/index.html.haml
+++ b/app/views/products/index.html.haml
@@ -191,9 +191,9 @@
   %p ©  FURIMA
 
 
-.exhibition
-  = link_to new_product_path, class:'link' do
-    .exhibition_btn
-      %span.text
-        出品する
-      = image_tag 'icon_camera.png', class: 'camera'
+  .exhibition
+    = link_to new_product_path, class:'exhibition__link' do
+      .exhibition_btn
+        %span.text
+          出品する
+        = image_tag 'icon_camera.png', class: 'camera'

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -131,7 +131,7 @@
               .productList
                 = link_to product_path(product), class: 'productList__link' do
                   %figure.productList__link__img
-                    = image_tag 'product.photos.first.image.url', class: 'imges' 
+                    = image_tag product.photos.first.image.url, class: 'imges' 
                   .productList__body
                     %h3.name
                       = product.name

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -3,7 +3,7 @@
 
 .main
   .main__show
-    .contents
+    .show__contents
       .contents__cont
         .itemBox
           %h2.itemBox__name
@@ -22,8 +22,12 @@
             .itemBox__price-detail
               %span
                 (税込)
-              %span
-                (送料込み)
+              - if @product.postage_payer == 1
+                %span
+                  (送料込み)
+              - else
+                %span
+                  (送料別)
           .itemDetail
             = @product.introduction
           .table
@@ -33,16 +37,26 @@
                   %th.info
                     出品者
                   %td.import
-                    name
+                    = @product.seller.nickname
                 %tr
                   %th.info
                     カテゴリー
-                  %td.import
-                    = @product.category.name
+                  %td.import.product_category
+                    %p
+                      = link_to "#{@parent.name}", '#'
+                    %p
+                      = link_to "#{@child.name}", '#'
+                    %p
+                      = link_to "#{@grandchild.name}", '#'
                 %tr
                   %th.info
                     ブランド
-                  %td.import
+                  - if @product.brand.present?
+                    %td.import
+                      = @product.brand.name
+                  - else
+                    %td.import
+                      なし
                 %tr
                   %th.info
                     商品のサイズ
@@ -62,7 +76,8 @@
                   %th.info
                     発送元の地域
                   %td.import
-                    = @product.prefecture_code
+                    %p
+                      = link_to "#{@product.prefecture_code}", '#'
                 %tr
                   %th.info
                     発送日の目安
@@ -82,8 +97,8 @@
           - unless @user.id == @product.seller_id
             = link_to '購入する', purchase_product_path(@product), class: "purchase-btn"
           - else 
-            = link_to '商品の編集', edit_product_path(@product)
-            = link_to '商品の削除', product_path(@product), method: :delete
+            = link_to '編集', edit_product_path(@product)
+            = link_to '削除', product_path(@product), method: :delete
         .commentBox
           %textarea.commentBox__comment
           %p.commentBox__noticeMsg
@@ -94,75 +109,44 @@
           %button.commentBox__btn
             %i.fa.fa-comment
               コメントする
-      .links
+      .show__links
         %ul.linksPage
           %li.before
-            = link_to "#",class: 'links__next' do
-              %i.fa.fa-angle-left
-                %span
-                  前の商品
+            - unless @prev_product.blank?
+              = link_to product_path(@prev_product), class: 'show__links__next' do
+                %i.fa.fa-angle-left
+                  %span
+                    前の商品
           %li.after
-            = link_to "#", class: 'links__next' do
-              %span
-                後ろの商品
-                %i.fa.fa-angle-right
+            - unless @next_product.blank?
+              = link_to product_path(@next_product), class: 'show__links__next' do
+                %span
+                  後ろの商品
+                  %i.fa.fa-angle-right
       .relatedItem
-        = link_to "#", class: 'relatedItem__watch' do
-          レディースをもっと見る
+        = link_to "#{@parent.name}をもっと見る", '#', class: 'relatedItem__watch'
         .productLists
-          .productList
-            = link_to "#", class: 'productList__link' do
-              %figure.productList__link__img
-                = image_tag '',class: 'imges' 
-              .productList__body
-                %h3.name
-                  テスト
-                .datails
-                  %ul
-                    %li
-                      10000円
-                    %li
-                      = icon('fa', 'star') 
-                      1
-                  %p
-                    (税込)
-          .productList
-            = link_to "#", class: 'productList__link' do
-              %figure.productList__link__img
-                = image_tag '',class: 'imges' 
-              .productList__body
-                %h3.name
-                  テスト
-                .datails
-                  %ul
-                    %li
-                      10000円
-                    %li
-                      = icon('fa', 'star') 
-                      1
-                  %p
-                    (税込)
-          .productList
-            = link_to "#", class: 'productList__link' do
-              %figure.productList__link__img
-                = image_tag '',class: 'imges' 
-              .productList__body
-                %h3.name
-                  テスト
-                .datails
-                  %ul
-                    %li
-                      10000円
-                    %li
-                      = icon('fa', 'star') 
-                      1
-                  %p
-                    (税込)
- 
-
+          - if @parent_category_products.present?
+            - @parent_category_products.each do |product|
+              .productList
+                = link_to product_path(product), class: 'productList__link' do
+                  %figure.productList__link__img
+                    = image_tag 'product.photos.first.image.url', class: 'imges' 
+                  .productList__body
+                    %h3.name
+                      = product.name
+                    .datails
+                      %ul
+                        %li
+                          = "#{product.price}円"
+                        %li
+                          = icon('fa', 'star') 
+                          1
+                      %p
+                        (税込)
 
 .appbar
-  .content
+  .show__content
     %h2.content_title
       だれでもかんたん、人生を変えるフリマアプリ
     %p.content_text
@@ -209,9 +193,9 @@
   %p ©  FURIMA
 
 
-.exhibition
-  = link_to "#", class:'link' do
-    .exhibition_btn
-      %span.text
-        出品する
-      = image_tag 'icon_camera.png', class: 'camera' 
+  .exhibition
+    = link_to "#", class:'exhibition__link' do
+      .exhibition_btn
+        %span.text
+          出品する
+        = image_tag 'icon_camera.png', class: 'camera' 


### PR DESCRIPTION
# What
商品詳細ページにカテゴリ表示機能を実装した。
商品に関連づいたカテゴリの親・子・孫カテゴリ名がそれぞれ表示されるように実装。
ページ下部に商品の親カテゴリに関連付いた商品のリンクが3つ表示されるよう設定した。
なお、「前の商品」「次の商品」リンクについても、各商品詳細情報に適切にアクセス出来るよう機能を追加した。

# Why
商品詳細情報としてカテゴリ名を正しく表示させる為。

<img width="1140" alt="4e2d656cd613be518557a29d611edb94" src="https://user-images.githubusercontent.com/65937890/89760793-0eb2e000-db28-11ea-9bf4-d2193b4ba8e5.png">

<img width="1146" alt="be81c497f3a510f7e592f17bdce22409" src="https://user-images.githubusercontent.com/65937890/89760816-16728480-db28-11ea-99ce-c7561da58f90.png">
