### PR TITLE
購入機能エラーハンドリング

### DIFF
--- a/app/assets/stylesheets/products_details.scss
+++ b/app/assets/stylesheets/products_details.scss
@@ -92,6 +92,26 @@
               }
             }
           }
+          .anyBtn-purchase {
+            margin-top: 30px;
+            &__link {
+              background-color: $color_item3;
+              padding: 15px;
+              border-radius: 15px;
+              text-decoration: none;
+              color: white;
+              font-weight: bold;
+              &__delete {
+                background-color: red;
+                padding: 15px;
+                margin-left: 1rem;
+                border-radius: 15px;
+                text-decoration: none;
+                color: white;
+                font-weight: bold;
+              }
+            }
+          }
         }
         .commentBox{
           padding: 24px;

--- a/app/controllers/products_controller.rb
+++ b/app/controllers/products_controller.rb
@@ -9,6 +9,8 @@ class ProductsController < ApplicationController
 
   def show
     @user = current_user
+    Payjp.api_key = ENV['PAYJP_PRIVATE_KEY']
+    @card = CreditCard.find_by(user_id: current_user)
   end
 
   def new

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -80,10 +80,13 @@
                     不適切な商品の通報
           .anyBtn-purchase
           - unless @user.id == @product.seller_id
-            = link_to '購入する', purchase_product_path(@product), class: "purchase-btn"
+            - if @card.blank?
+              = link_to '購入には、こちらから、クレジットカードの登録が必要です', new_credit_card_path, class: "anyBtn-purchase__link"
+            - else 
+              = link_to '購入する', purchase_product_path(@product), class: "anyBtn-purchase__link"
           - else 
-            = link_to '商品の編集', edit_product_path(@product)
-            = link_to '商品の削除', product_path(@product), method: :delete
+            = link_to '商品の編集', edit_product_path(@product), class: "anyBtn-purchase__link"
+            = link_to '商品の削除', product_path(@product), method: :delete, class: "anyBtn-purchase__link__delete"
         .commentBox
           %textarea.commentBox__comment
           %p.commentBox__noticeMsg

--- a/app/views/users/show.html.haml
+++ b/app/views/users/show.html.haml
@@ -14,7 +14,6 @@
           = link_to 'クレジットカードの登録', new_credit_card_path, class: "ItemLeft__credit"
         - else
           = link_to 'クレジットカードの詳細', credit_card_path(@card)
-          -# = link_to 'クレジットカードの編集・削除', edit_credit_card_path(@card), class: "ItemLeft__credit"
       %li.ItemLeft
         = link_to 'ログアウト', destroy_user_session_path, method: :delete, class: "ItemLeft__logout"
   .wrapper__Right

--- a/spec/factories/credit_cards.rb
+++ b/spec/factories/credit_cards.rb
@@ -1,6 +1,6 @@
 FactoryBot.define do
   factory :credit_card do
-    user { nil }
+    user 
     customer_id { "MyString" }
     card_id { "MyString" }
   end

--- a/spec/models/credit_card_spec.rb
+++ b/spec/models/credit_card_spec.rb
@@ -1,5 +1,19 @@
 require 'rails_helper'
-
-# RSpec.describe CreditCard, type: :model do
-#   pending "add some examples to (or delete) #{__FILE__}"
-# end
+describe CreditCard do
+  describe "#create" do
+    it "is valid with a user_id, customer_id card_id" do
+      credit_card = build(:credit_card)
+      expect(credit_card).to be_valid
+    end
+    it "is invalid without a customer_id" do
+      credit_card = build(:credit_card, customer_id: "")
+      credit_card.valid?
+      expect(credit_card.errors[:customer_id]).to include( "を入力してください" )
+    end
+    it "is invalid without a card_id" do
+      credit_card = build(:credit_card, card_id: "")
+      credit_card.valid?
+      expect(credit_card.errors[:card_id]).to include("を入力してください")
+    end
+  end
+end


### PR DESCRIPTION
#What
クレジットカードが登録されていなければ購入へのリンクを踏めない条件分岐の記述と、テストコードを追加した。

#Why
ユーザーフレンドリーなメッセージ表示にするため。

https://gyazo.com/2ae22e7814088cd92ad1f98d1a94e190
https://gyazo.com/2594f8804241e5c7797298378dab97da
https://gyazo.com/d9b19a6510cb8c16a099104e90063dea