### PR TITLE
商品詳細ページ修正

### DIFF
--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -18,7 +18,7 @@
                       = image_tag product_image.image.url, class: 'imges__picture'
           .itemBox__price
             %span
-              = @product.price
+              = "#{@product.price}円"
             .itemBox__price-detail
               %span
                 (税込)
@@ -102,17 +102,20 @@
                   %i.fa.fa-flag
                     不適切な商品の通報
           .anyBtn-purchase
-          - unless @user.id == @product.seller_id
-            - if @product.buyer_id.nil?
-              - if @card.blank?
-                = link_to '購入には、こちらから、クレジットカードの登録が必要です', new_credit_card_path, class: "anyBtn-purchase__link"
-              - else 
-                = link_to '購入する', purchase_product_path(@product), class: "anyBtn-purchase__link"
-            - else
-              %button.anyBtn-purchase__sold 購入済み
+          - if user_signed_in?
+            - unless @user.id == @product.seller_id
+              - if @product.buyer_id.nil?
+                - if @card.blank?
+                  = link_to '購入には、こちらから、クレジットカードの登録が必要です', new_credit_card_path, class: "anyBtn-purchase__link"
+                - else 
+                  = link_to '購入する', purchase_product_path(@product), class: "anyBtn-purchase__link"
+              - else
+                %button.anyBtn-purchase__sold 購入済み
+            - else 
+              = link_to '商品の編集', edit_product_path(@product), class: "anyBtn-purchase__link"
+              = link_to '商品の削除', product_path(@product), method: :delete, class: "anyBtn-purchase__link__delete"
           - else 
-            = link_to '商品の編集', edit_product_path(@product), class: "anyBtn-purchase__link"
-            = link_to '商品の削除', product_path(@product), method: :delete, class: "anyBtn-purchase__link__delete"
+            = link_to '購入には、ログインが必要です', new_user_session_path, class: "anyBtn-purchase__link"
         .commentBox
           %textarea.commentBox__comment
           %p.commentBox__noticeMsg


### PR DESCRIPTION
#What
ログアウトした状態でも、商品詳細ページの閲覧でき、且「購入にはログインが必要です」というメッセージが表示されるよう修正を加えた。

#Why
より、ユーザーフレンドリーなアプリにするため。